### PR TITLE
Added the support to block the API calls based on Client IP and email domains. 

### DIFF
--- a/base/ipfilter.go
+++ b/base/ipfilter.go
@@ -1,0 +1,174 @@
+package base
+
+import (
+	"bytes"
+	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/viper"
+	"net"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+type Prohibited struct {
+	ips     map[string]bool
+	subnets []*subnet
+	ranges  []*iprange
+}
+
+type subnet struct {
+	ip    string
+	ipnet *net.IPNet
+}
+
+type iprange struct {
+	start net.IP
+	end   net.IP
+}
+
+var ProhibitedIPs Prohibited
+var ProhibitedDomains string
+
+func InitProhibitedIPs() {
+	ProhibitedIPs.ips = make(map[string]bool)
+	config := viper.New()
+	config.SetConfigName("prohibited")
+	config.SetConfigType("yaml")
+	config.AddConfigPath("/usr/local/production/config/")
+
+	err := config.ReadInConfig()
+	if err != nil {
+		Zlog.Errorf("Falied to Initialise the Prohibited domain data: %s", err.Error())
+	}
+	blockedIPs := config.GetString("BANNED_IP")
+	ProhibitedDomains = config.GetString("BANNED_DOMAINS")
+	UpdateProhibitedIPs(blockedIPs)
+	config.OnConfigChange(func(e fsnotify.Event) {
+		Zlog.Infof("Config file chnaged")
+		blockedIPs = config.GetString("BANNED_IP")
+		ProhibitedDomains = config.GetString("BANNED_DOMAINS")
+		UpdateProhibitedIPs(blockedIPs)
+	})
+	config.WatchConfig()
+}
+
+func UpdateProhibitedIPs(blockedIPs string) {
+	ips := make(map[string]bool)
+	var subnets []*subnet
+	var ranges []*iprange
+	networkCheckpoints := strings.Split(strings.ReplaceAll(blockedIPs, " ", ""), ",")
+	for _, checkpoint := range networkCheckpoints {
+		Zlog.Infof("Processing:%s", checkpoint)
+		if strings.Index(checkpoint, "-") != -1 {
+			Zlog.Infof("Matching: %s", checkpoint)
+			ipRange := strings.Split(checkpoint, "-")
+			startIPnet := net.ParseIP(ipRange[0])
+			endIPnet := net.ParseIP(ipRange[1])
+			if endIPnet == nil || startIPnet == nil {
+				Zlog.Errorf("Invalid IP Range [%s-%s]", ipRange[0], ipRange[1])
+				continue
+			}
+			ranges = append(ranges, &iprange{
+				start: startIPnet,
+				end:   endIPnet,
+			})
+		} else if strings.Index(checkpoint, "/") != -1 {
+			Zlog.Infof("Matching /", checkpoint)
+			_, network, err := net.ParseCIDR(checkpoint)
+			if err != nil {
+				Zlog.Errorf("Invalid Subnet [%s]", checkpoint)
+				continue
+			}
+			subnets = append(subnets, &subnet{
+				ip:    checkpoint,
+				ipnet: network,
+			})
+		} else if len(checkpoint) > 0 {
+			Zlog.Infof(checkpoint)
+			ip := net.ParseIP(checkpoint)
+			if ip != nil {
+				ips[ip.String()] = true
+			} else {
+				Zlog.Errorf("Invalid IP [%s]", checkpoint)
+			}
+		}
+	}
+	ProhibitedIPs.ips = ips
+	ProhibitedIPs.subnets = subnets
+	ProhibitedIPs.ranges = ranges
+}
+
+func ValidateClientIP(req *http.Request) bool {
+	clientIP := GetClientIP(req)
+	Zlog.Infof("Checking if the Client IP [%s] belongs to blocked IP list", clientIP)
+	clientIPnet := net.ParseIP(clientIP)
+	if _, found := ProhibitedIPs.ips[clientIPnet.String()]; found {
+		Zlog.Errorf("IP address [%s] belongs to blocked IPs", clientIP)
+		return false
+	}
+	for _, subnet := range ProhibitedIPs.subnets {
+		if subnet.ipnet.Contains(clientIPnet) {
+			Zlog.Errorf("IP address [%s] belongs to blocked Subnet [%s]", clientIP, subnet.ip)
+			return false
+		}
+	}
+	for _, iprange := range ProhibitedIPs.ranges {
+		if bytes.Compare(clientIPnet, iprange.start) >= 0 && bytes.Compare(clientIPnet, iprange.end) <= 0 {
+			Zlog.Errorf("IP address [%s] belongs to blocked IP Range [%s-%s]", clientIP, iprange.start.String(), iprange.end.String())
+			return false
+		}
+	}
+	return true
+}
+
+func ValidateDomain(userEmail string) bool {
+	if len(ProhibitedDomains) == 0 {
+		Zlog.Infof("Blacklisted domains are not defined")
+		return true
+	}
+	blockedDomains := strings.Split(strings.ReplaceAll(ProhibitedDomains, " ", ""), ",")
+	at := strings.LastIndex(userEmail, "@")
+	userDomain := userEmail[at+1:]
+	Zlog.Infof("Verifying if email Domain[%s] belongs to the Banned domains.", userDomain)
+	for _, bdomain := range blockedDomains {
+		domain := strings.ReplaceAll(bdomain, ".", `\.`)
+		domain = strings.ReplaceAll(domain, "*", ".*")
+		Zlog.Debugf("Domains:[%s]:[%s]", bdomain, domain)
+		emailRegex := regexp.MustCompile(domain)
+		match := emailRegex.FindString(userDomain)
+		if match != "" {
+			Zlog.Errorf("Banned domain found:%s", bdomain)
+			Zlog.Errorf("User email Domain [%s] belongs to the Banned domains [%s]", userDomain, bdomain)
+			return false
+		}
+	}
+	Zlog.Infof("User email Domain [%s] is safe to procced", userDomain)
+	return true
+}
+
+func GetClientIP(r *http.Request) string {
+	ip := r.Header.Get("X-REAL-IP")
+	netip := net.ParseIP(ip)
+	if netip != nil {
+		return ip
+	}
+
+	xfips := r.Header.Get("X-FORWARDED-FOR")
+	ips := strings.Split(xfips, ",")
+	for _, ip := range ips {
+		netip = net.ParseIP(ip)
+		if netip != nil {
+			return ip
+		}
+	}
+	// Get the IP from remote Addr
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return ""
+	}
+	netip = net.ParseIP(ip)
+	if netip != nil {
+		return ip
+	}
+	return ""
+}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -158,6 +158,9 @@ func ShiftPath(p string) (head, tail string) {
 }
 
 func checkAccess(w http.ResponseWriter, r *http.Request, login string, command string) bool {
+	if base.ValidateClientIP(r) == false {
+		return false
+	}
 	switch command {
 	case "get_token":
 		return r.Method == http.MethodGet || r.Method == http.MethodPost
@@ -303,6 +306,11 @@ func home(w http.ResponseWriter, r *http.Request) {
 	// And need to re route the end user to an end of session
 	switch head {
 	case "get_server_models":
+		base.Zlog.Infof("GET SERVER MODEL")
+		if base.ValidateClientIP(r) == false {
+			http.Error(w, "Service is not available", 401)
+			return
+		}
 		var activeProducts []serverProduct
 		for i := range ciServersProducts {
 			if ciServersProducts[i].Active != 0 {
@@ -953,6 +961,8 @@ func main() {
 		}
 	}
 
+	base.InitProhibitedIPs()
+
 	if DNSDomain != "" {
 		// if DNS_DOMAIN is set then we run in a production environment
 		// we must get the directory where the certificates will be stored
@@ -984,7 +994,8 @@ func main() {
 	} else {
 		go http.ListenAndServe(":80", http.HandlerFunc(httpsRedirect))
 		// Launch TLS server
-		if err := http.ListenAndServeTLS(":443", tlsCertPath, tlsKeyPath, mux); err != nil {
+		err := http.ListenAndServeTLS(":443", tlsCertPath, tlsKeyPath, mux)
+		if err != nil {
 			base.Zlog.Fatalf("Server TLS error: %s", err.Error())
 		}
 	}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -306,7 +306,6 @@ func home(w http.ResponseWriter, r *http.Request) {
 	// And need to re route the end user to an end of session
 	switch head {
 	case "get_server_models":
-		base.Zlog.Infof("GET SERVER MODEL")
 		if base.ValidateClientIP(r) == false {
 			http.Error(w, "Service is not available", 401)
 			return
@@ -961,7 +960,10 @@ func main() {
 		}
 	}
 
-	base.InitProhibitedIPs()
+	err = base.InitProhibitedIPs()
+	if err != nil {
+		base.Zlog.Warnf("IP filter initialization error: %s", err.Error())
+	}
 
 	if DNSDomain != "" {
 		// if DNS_DOMAIN is set then we run in a production environment

--- a/gateway/user.go
+++ b/gateway/user.go
@@ -212,6 +212,10 @@ func createUser(username string, w http.ResponseWriter, r *http.Request) bool {
 	updatedData = new(base.User)
 	updatedData.Nickname = username
 	updatedData.Email = r.FormValue("email")
+	if base.ValidateDomain(updatedData.Email) == false {
+		fmt.Fprint(w, "Error")
+		return false
+	}
 
 	// this is a creation
 	updatedData.TokenAuth = base.GenerateAccountACKLink(20)
@@ -347,9 +351,9 @@ func deleteUser(username string, w http.ResponseWriter, r *http.Request) bool {
 	updatedData.Active = 0
 	//c, _ := json.Marshal(updatedData)
 	//base.HTTPPutRequest("http://"+StorageURI+StorageTCPPORT+"/user/"+updatedData.Nickname, c, "application/json")
-	base.HTTPDeleteRequest("http://"+StorageURI+StorageTCPPORT+"/user/"+updatedData.Nickname)
+	base.HTTPDeleteRequest("http://" + StorageURI + StorageTCPPORT + "/user/" + updatedData.Nickname)
 	if newData.DeleteData == "true" {
-		base.HTTPDeleteRequest("http://"+StorageURI+StorageTCPPORT+"/user/"+updatedData.Nickname+"/delete_user_data")
+		base.HTTPDeleteRequest("http://" + StorageURI + StorageTCPPORT + "/user/" + updatedData.Nickname + "/delete_user_data")
 	}
 	// And return positively
 	return true
@@ -601,6 +605,9 @@ func main() {
 	if err != nil {
 		base.Zlog.Fatalf("Initialization error: %s", err.Error())
 	}
+
+	// Initializing the list of  blocked Domain and IP
+	base.InitProhibitedIPs()
 
 	mux := http.NewServeMux()
 	print("Attaching to " + CredentialURI + "\n")

--- a/gateway/user.go
+++ b/gateway/user.go
@@ -607,7 +607,10 @@ func main() {
 	}
 
 	// Initializing the list of  blocked Domain and IP
-	base.InitProhibitedIPs()
+	err = base.InitProhibitedIPs()
+	if err != nil {
+		base.Zlog.Warnf("IP filter initialization error: %s", err.Error())
+	}
 
 	mux := http.NewServeMux()
 	print("Attaching to " + CredentialURI + "\n")


### PR DESCRIPTION
We need to have a YAML file name 'prohibited.yaml" with following keys.

BANNED_DOMAINS: (comma separated domain names, wildcard asterisk * is acceptable )
BANNED_IP: (Comma separated IPs, it can be single IP, Subnet, or range of IPs)

e.g. 
BANNED_DOMAINS: xyz.com, *abc*, *abcd.com
BANNED_IP: 10.10.1.1, 10.1.1.1/24, 10.10.1.1-10.10.1.100

Newly added: base/ipfilter.go
This package will read from Yaml file, and store it in a data structure .  For a HTTP request, it will try to search the Client IP in the data structure to find the match, and will flag the HTTP request accordingly 