### PR TITLE
Removed the cat command

### DIFF
--- a/compile/Dockerfile.linuxboot
+++ b/compile/Dockerfile.linuxboot
@@ -12,7 +12,6 @@ COPY . .
 # lets build
 RUN echo $http_proxy
 RUN cat /etc/resolv.conf 
-RUN cat /etc/apt/apt.conf.d/proxy.conf
 ENV GOPATH=$GOPATH:/go/src/base
 RUN apt-get --allow-unauthenticated update --allow-insecure-repositories
 RUN apt-get update && apt install -qq -y locales


### PR DESCRIPTION
Removed the below command. Public CI doesn't use a  proxy, so the proxy file doesn't exist for Public CI. 

RUN cat /etc/apt/apt.conf.d/proxy.conf


Signed-off-by: Susmith Poochali <susmith.p@gmail.com>