### PR TITLE
Fix for OpenBmc build hang issue

### DIFF
--- a/compile/build_openbmc
+++ b/compile/build_openbmc
@@ -8,7 +8,8 @@ if [ "$PROXY" != "" ]
 then
 git config --global https.proxy $PROXY
 git config --global http.proxy $PROXY
-git config --global url.https://github.com/.insteadOf git://github.com/
+#git config --global url.https://github.com/.insteadOf git://github.com/
+git config --global url."https://".insteadOf git://
 npm config set proxy $PROXY
 npm config set https-proxy $PROXY
 export http_proxy=$PROXY


### PR DESCRIPTION
OpenBMC build was getting hang and failed with the following error. 

Failed to fetch URL git://git.yoctoproject.org/pseudo;branch=oe-core

ERROR: pseudo-native-1.9.0+gitAUTOINC+b988b0a6b8-r0 do_unpack: Unpack failure for URL: 'git://git.yoctoproject.org/pseudo;branch=oe-core'. No up to date source found: