### PR TITLE
Fix for Issue #33 OpenBMC build fails to fetch from public github repos

### DIFF
--- a/compile/build_openbmc
+++ b/compile/build_openbmc
@@ -4,12 +4,12 @@
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 echo "proxy in use: $PROXY"
 
+git config --global url."https://".insteadOf git://
 if [ "$PROXY" != "" ]
 then
 git config --global https.proxy $PROXY
 git config --global http.proxy $PROXY
 #git config --global url.https://github.com/.insteadOf git://github.com/
-git config --global url."https://".insteadOf git://
 npm config set proxy $PROXY
 npm config set https-proxy $PROXY
 export http_proxy=$PROXY


### PR DESCRIPTION
Signed-off-by: Susmith Poochali <susmith.p@gmail.com>

Moved the git URL replace command outside of the proxy check block.

We already had the command to use 'HTTPS' instead of 'git' but it was inside the "if" block for the proxy check.  The same code was working fine at dev ci because we use proxy in dev. But in public ci, as we don't use a proxy, the command next gets executed. 

