### PR TITLE
Private Key Download Button

### DIFF
--- a/gateway/html/navbar.html
+++ b/gateway/html/navbar.html
@@ -67,7 +67,7 @@
     
     <!-- Private Keys Button -->
     <form method="get" action="/get_private_key">
-      <button type="submit" class="btn btn-primary" id="download_key_button" data-toggle="modal" data-target="#myModal">
+      <button type="submit" class="btn btn-primary" id="download_key_button" data-toggle="modal" data-target="#myModal" style="display: none;">
         Download Private Key
       </button>
     </form>

--- a/gateway/html/navbar.html
+++ b/gateway/html/navbar.html
@@ -1,5 +1,27 @@
 <header class="sticky-top" style="z-index:10000">
 <div style="background-color:#282828">
+
+<!-- PopUp -->
+<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel">Popup Title</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>A private key must be included in any OpenBMC build to be used with the OSFCI. You can download said key from the "Download Private Key" button. Once downloaded, place the key into the following directory of your source tree: openbmc/meta-hpe/meta-gxp/recipes-bsp/image/files.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="mylocalStorage['privKeyInfoAck'] = 1">Acknowledge</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!--Navbar-->
 <nav class="navbar sticky-top navbar-expand-lg navbar-dark primary-color">
 
@@ -42,6 +64,14 @@
     <div class="navbar-text" id="counter" style="color:#228B22"></div>
     <button type="button" class="btn btn-danger btn-sm" id='EndSession' style="display:none; margin-left:10px;"
 	data-toggle="modal" data-target="#modalSession" >End Session</button>
+    
+    <!-- Private Keys Button -->
+    <form method="get" action="private_key.pem">
+      <button type="submit" class="btn btn-primary" id="download_key_button" data-toggle="modal" data-target="#myModal">
+        Download Private Key
+      </button>
+    </form>
+    
     <!-- Dropdown -->
     <li class="nav-item dropdown ml-md-auto" id="dropdownMaster">
         <a class="nav-link dropdown-toggle" id="navbarDropdownMenuLink" data-toggle="dropdownMaster"

--- a/gateway/html/navbar.html
+++ b/gateway/html/navbar.html
@@ -6,7 +6,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLabel">Popup Title</h5>
+        <h5 class="modal-title" id="exampleModalLabel">How to Make Things Work!</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/gateway/html/navbar.html
+++ b/gateway/html/navbar.html
@@ -66,7 +66,7 @@
 	data-toggle="modal" data-target="#modalSession" >End Session</button>
     
     <!-- Private Keys Button -->
-    <form method="get" action="private_key.pem">
+    <form method="get" action="/get_private_key">
       <button type="submit" class="btn btn-primary" id="download_key_button" data-toggle="modal" data-target="#myModal">
         Download Private Key
       </button>

--- a/gateway/js/app.js
+++ b/gateway/js/app.js
@@ -187,6 +187,8 @@ function run_ci(servername, RemainingSecond) {
 	$('#features').css("display","none");
 	$('#help').css("display","none");
 	$('#dropdown').css("display","none");
+	$('#download_key_button').css("display","none");
+
 
 
 	// We must add an input field into the navbar to gather the github Token entry
@@ -888,6 +890,9 @@ function myAccount()
 
 function logged()
 {
+	if (typeof(mylocalStorage['privKeyInfoAck'] == 'undefined')) {
+		mylocalStorage['privKeyInfoAck'] = 0;
+	}
 	mainpage();
 }
 
@@ -909,6 +914,7 @@ function disconnect()
 	delete mylocalStorage['secretKey'];
 	delete mylocalStorage['username'];
 	delete mylocalStorage['osfciauth'];
+	delete mylocalStorage['privKeyInfoAck'];
 	localStorage.clear()
 	// Wait 5s and redirect to mainpage
 	setTimeout(function () {
@@ -922,6 +928,10 @@ function mainpage(){
 	loadHTML("html/navbar.html");
 	loadJS("js/navbar.js");
 	navbarHover();
+	// pretty rudimentary I should probably keep this within the popUp function itself eventually
+	if (mylocalStorage['privKeyInfoAck'] != 1) {
+		popUp()
+	}
 	loginBtn();
 	loadHTML("html/home.html");
 	$('#background').css('background-image', 'url(images/landing.png)').fadeIn(3000);

--- a/gateway/js/app.js
+++ b/gateway/js/app.js
@@ -372,7 +372,7 @@ function run_ci(servername, RemainingSecond) {
 						$("#EndSession").css("display","none");
 						$("#modalSession").modal('hide');
 						$('#modalSession').on('hidden.bs.modal', function (e) {
-							mainpage(); //This was main() before -> I think it was a mistake :) 
+							mainpage();
 						});
                                         }
                                 });

--- a/gateway/js/app.js
+++ b/gateway/js/app.js
@@ -926,7 +926,7 @@ function mainpage(){
 	clearDocument();
 	// Must load the default home page
 	loadHTML("html/navbar.html");
-	$('#download_key_button').css("display","show");
+	$('#download_key_button').removeAttr("style");
 	loadJS("js/navbar.js");
 	navbarHover();
 	// pretty rudimentary I should probably keep this within the popUp function itself eventually

--- a/gateway/js/app.js
+++ b/gateway/js/app.js
@@ -926,6 +926,7 @@ function mainpage(){
 	clearDocument();
 	// Must load the default home page
 	loadHTML("html/navbar.html");
+	$('#download_key_button').css("display","show");
 	loadJS("js/navbar.js");
 	navbarHover();
 	// pretty rudimentary I should probably keep this within the popUp function itself eventually
@@ -934,6 +935,7 @@ function mainpage(){
 	}
 	loginBtn();
 	loadHTML("html/home.html");
+
 	$('#background').css('background-image', 'url(images/landing.png)').fadeIn(3000);
         $(document).ready(function () {
                     $('#background').animate({ opacity: 1 }, { duration: 2000 });

--- a/gateway/js/app.js
+++ b/gateway/js/app.js
@@ -128,6 +128,7 @@ function start_ci(machine) {
 
         clearDocument();
         loadHTML("html/navbar.html");
+		$('#download_key_button').removeAttr("style");
         loadJS("js/navbar.js");
         navbarHover();
         loginBtn();

--- a/gateway/js/app.js
+++ b/gateway/js/app.js
@@ -919,7 +919,7 @@ function disconnect()
 	localStorage.clear()
 	// Wait 5s and redirect to mainpage
 	setTimeout(function () {
-		mainpage();
+		main();
     	}, 5000);
 }
 

--- a/gateway/js/app.js
+++ b/gateway/js/app.js
@@ -372,7 +372,7 @@ function run_ci(servername, RemainingSecond) {
 						$("#EndSession").css("display","none");
 						$("#modalSession").modal('hide');
 						$('#modalSession').on('hidden.bs.modal', function (e) {
-							main();
+							mainpage(); //This was main() before -> I think it was a mistake :) 
 						});
                                         }
                                 });

--- a/gateway/js/navbar.js
+++ b/gateway/js/navbar.js
@@ -106,6 +106,10 @@ function enableDisableToolTip() {
     }
   }
 
+function popUp() {
+	$('#myModal').modal('show');	
+}
+
 // We have to build the navbar production option
 
 $.ajax({

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -11,8 +11,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/viper"
-	"golang.org/x/crypto/acme/autocert"
 	"html/template"
 	"io/ioutil"
 	"net"
@@ -24,25 +22,28 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/spf13/viper"
+	"golang.org/x/crypto/acme/autocert"
 )
 
 var tlsCertPath string
 var tlsKeyPath string
 
-//DNSDomain is read from config
+// DNSDomain is read from config
 var DNSDomain string
 var staticAssetsDir string
 
-//TTYDTestConsole is read from config
+// TTYDTestConsole is read from config
 var TTYDTestConsole string
 
-//TTYDHostConsole is read from config
+// TTYDHostConsole is read from config
 var TTYDHostConsole string
 
-//TTYDem100Bios is read from config
+// TTYDem100Bios is read from config
 var TTYDem100Bios string
 
-//TTYDem100BMC is read from config
+// TTYDem100BMC is read from config
 var TTYDem100BMC string
 
 // TTYDOSLoader is read from config
@@ -56,13 +57,13 @@ var credentialPort string
 var compileURI string
 var compileTCPPort string
 
-//StorageURI is read from config
+// StorageURI is read from config
 var StorageURI string
 
-//StorageTCPPORT is read from config
+// StorageTCPPORT is read from config
 var StorageTCPPORT string
 
-//MaxServerAge is read from config
+// MaxServerAge is read from config
 var MaxServerAge int
 
 type serverProduct struct {
@@ -96,7 +97,7 @@ type serversList struct {
 
 var ciServers serversList
 
-//Initialize the config variables
+// Initialize the config variables
 func initServerconfig() error {
 	viper.SetConfigName("gatewayconf")
 	viper.SetConfigType("yaml")
@@ -339,6 +340,18 @@ func home(w http.ResponseWriter, r *http.Request) {
 			base.Zlog.Fatalf("JSON encoding error: %s", err.Error())
 		}
 		w.Write([]byte(returnData))
+
+	case "get_private_key":
+		returnData, err := ioutil.ReadFile("/usr/local/production/keys/customer_private_key.pem")
+		if err != nil {
+			base.Zlog.Fatalf("JSON encoding error: %s", err.Error())
+		}
+		//if read is sucessful, get some information about the person doing stuff
+		base.Zlog.Infof("get_private_key: %s - %s %s %s", r.RemoteAddr, r.Proto, r.Method, r.URL.RequestURI())
+
+		//Tell response writer to send the requester the file data in question
+		w.Write([]byte(returnData))
+
 	case "get_server":
 		base.Zlog.Infof("get_server: %s - %s %s %s", r.RemoteAddr, r.Proto, r.Method, r.URL.RequestURI())
 		var serverTypeIndex int
@@ -1045,7 +1058,7 @@ func testweb(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-//Default Intialize
+// Default Intialize
 func init() {
 
 	config := base.Configuration{


### PR DESCRIPTION
Made front end and back end changes to allow a prospective OSFCI user to download private keys to enable them to load their own firmware into the dev ci tool. 

Steps to Test Basic Functionality Works (Popup and Download Button appears, and making sure pop up doesn't show up again in your current login instance):

1) Open up the Dev CI homepage. Ensure that the download button or pop up does not appear.
2) Log in. After you complete this process, a pop up should appear along with a Download Private Keys button on the far right (to the left of the drop down). 
3) Click acknowledge to make sure the pop up goes away until next log in. You can ensure this by typing ``mylocalStorage['privKeyInfoAck']`` in the console. A value of 1 should be returned. You can test to make sure that the pop up doesn't show up by clicking the home button. 


Steps to make sure the download private key button actually sends the correct get request. (Complete these steps after doing the first section)

1) Click the download private key button. The private key binary file should either download or open up in a new tab. 

Step to Ensure Download Private Key Button goes away correctly

Situation 1: After logging out

1) Click the logout button. The private key should disappear until you re login.

Situation 2: When you run CI. 

1) move your mouse over your username, a drop down should show up. Click any interactive session. Once you get out of the waitlist and the session starts, the download button should disappear on the nav bar. 

