### PR TITLE
Fix for "Connection reset" reverse proxy error with BMC web

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1138,18 +1138,11 @@ func main() {
 			servertype := viper.GetString(typetring)
 			fmt.Println("servertype=", servertype)
 			switch servertype {
-			case "DL360_Gen10":
-				newEntry.ProductIndex = 0
-			case "DL325_GEN10PLUS":
-				newEntry.ProductIndex = 1
-
-			case "RL300_GEN11":
-				newEntry.ProductIndex = 2
-			case "DL360_GEN11":
-				newEntry.ProductIndex = 3
-			case "DL360_GEN10_DEV":
-				newEntry.ProductIndex = 4
 			case "DL385_GEN11":
+				newEntry.ProductIndex = 0
+			case "DL325_GEN11":
+				newEntry.ProductIndex = 1
+			case "RL300_GEN11":
 				newEntry.ProductIndex = 5
 			}
 			ciServers.mux.Lock()

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1143,7 +1143,7 @@ func main() {
 			case "DL325_GEN11":
 				newEntry.ProductIndex = 1
 			case "RL300_GEN11":
-				newEntry.ProductIndex = 5
+				newEntry.ProductIndex = 2 
 			}
 			ciServers.mux.Lock()
 			ciServers.servers = append(ciServers.servers, newEntry)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -86,6 +86,7 @@ type serverEntry struct {
 	gitToken        string
 	queue           int
 	expiration      time.Time
+	ReverseProxy 	*httputil.ReverseProxy
 	ProductIndex    int
 }
 
@@ -614,6 +615,21 @@ func home(w http.ResponseWriter, r *http.Request) {
 		}
 	case "power_on":
 		if cacheIndex != -1 {
+			bmcIP := ciServers.servers[cacheIndex].bmcIP
+			url, _ := url.Parse("https://" + bmcIP + ":443")
+			ciServers.servers[cacheIndex].ReverseProxy = httputil.NewSingleHostReverseProxy(url)
+			var InsecureTransport http.RoundTripper = &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).Dial,
+				TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
+				TLSHandshakeTimeout: 10 * time.Second,
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 100,
+			}
+			// Our OpenBMC has a self signed certificate
+			ciServers.servers[cacheIndex].ReverseProxy.Transport = InsecureTransport
 			//fmt.Printf("Poweron request\n")
 			base.Zlog.Infof("Poweron request")
 			client := &http.Client{}
@@ -873,6 +889,7 @@ func bmcweb(w http.ResponseWriter, r *http.Request) {
 	// to the homepage !
 
 	bmcIP := ""
+	cacheIndex := -1
 	if err == nil {
 		if cookie.Value != "" {
 			// We must get the IP address from the cache
@@ -881,6 +898,7 @@ func bmcweb(w http.ResponseWriter, r *http.Request) {
 					if time.Now().Before(ciServers.servers[i].expiration) {
 						// We still own the server and we can go to the BMC
 						bmcIP = ciServers.servers[i].bmcIP
+						cacheIndex = i
 					}
 				}
 			}
@@ -913,22 +931,10 @@ func bmcweb(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	conn.Close()
-	// Must specify the iLo Web address
-	url, _ := url.Parse("https://" + bmcIP + ":443")
-	proxy := httputil.NewSingleHostReverseProxy(url)
-	var InsecureTransport http.RoundTripper = &http.Transport{
-		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).Dial,
-		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
-		TLSHandshakeTimeout: 10 * time.Second,
-	}
-	// Our OpenBMC has a self signed certificate
-	proxy.Transport = InsecureTransport
+	proxy := ciServers.servers[cacheIndex].ReverseProxy
 	// Internal gateway IP address
 	// Must reroute on myself and port 443
-	url, _ = url.Parse("http://" + r.Header.Get("Host"))
+	url, _ := url.Parse("http://" + r.Header.Get("Host"))
 	r.URL.Host = "https://" + url.Hostname() + ":443/"
 	r.Header.Set("X-Forwarded-Host", r.Header.Get("Host"))
 	proxy.ServeHTTP(w, r)
@@ -1137,6 +1143,14 @@ func main() {
 			case "DL325_GEN10PLUS":
 				newEntry.ProductIndex = 1
 
+			case "RL300_GEN11":
+				newEntry.ProductIndex = 2
+			case "DL360_GEN11":
+				newEntry.ProductIndex = 3
+			case "DL360_GEN10_DEV":
+				newEntry.ProductIndex = 4
+			case "DL385_GEN11":
+				newEntry.ProductIndex = 5
 			}
 			ciServers.mux.Lock()
 			ciServers.servers = append(ciServers.servers, newEntry)


### PR DESCRIPTION
1. Creating the reverse proxy only once and reusing it for every request. 
2. Increased the "MaxIdleConnsPerHost" to 100, otherwise default was 2. 