### PR TITLE
Dropdown-Security-Fix-1

### DIFF
--- a/gateway/html/navbar.html
+++ b/gateway/html/navbar.html
@@ -44,19 +44,7 @@
 	data-toggle="modal" data-target="#modalSession" >End Session</button>
     <!-- Dropdown -->
     <li class="nav-item dropdown ml-md-auto" id="dropdownMaster">
-        <a class="nav-link dropdown-toggle" id="navbarDropdownMenuLink" data-toggle="dropdownMaster"
-          aria-haspopup="true" aria-expanded="false">Dropdown</a>
-        <ul class="dropdown-menu dropdown-primary" aria-labelledby="navbarDropdownMenuLink" id="menuMaster">
-          <li><a class="dropdown-item" id='MyAccount'>My Account</a></li>
-          <li class="dropdown-submenu" id="dropdownSecondary">
-		<a class="dropdown-toggle" data-toggle="dropdownSecondary" aria-haspopup="true" aria-expanded="false" id='InteractiveSession'>
-			<span class="nav-label">Interactive Session</span><span class="caret"></span>
-		</a>
-		<ul class="dropdown-menu" aria-labelledby="InteractiveSession" id="menuSecondary">
-		  <li><a class="dropdown-item" id="dl360">dl360</a></li>
-		</ul>
-          </li>
-        </ul>
+      <!-- This is where the drop down html code should be inserted after log in-->
     </li>
     <button type="button" class="btn btn-light btn-sml" id='loginNavbar'>Login</button>
     </ul>

--- a/gateway/js/navbar.js
+++ b/gateway/js/navbar.js
@@ -1,3 +1,19 @@
+var dropdownCodeToInsert = `
+    <a class="nav-link dropdown-toggle" id="navbarDropdownMenuLink" data-toggle="dropdownMaster" 
+       aria-haspopup="true" aria-expanded="false">Dropdown</a>
+    <ul class="dropdown-menu dropdown-primary" aria-labelledby="navbarDropdownMenuLink" id="menuMaster">
+      <li><a class="dropdown-item" id='MyAccount'>My Account</a></li>
+      <li class="dropdown-submenu" id="dropdownSecondary">
+        <a class="dropdown-toggle" data-toggle="dropdownSecondary" aria-haspopup="true" aria-expanded="false" id='InteractiveSession'>
+          <span class="nav-label">Interactive Session</span><span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="InteractiveSession" id="menuSecondary">
+          <li><a class="dropdown-item" id="dl360">dl360</a></li>
+        </ul>
+      </li>
+    </ul>
+  `;
+
 function navbarHover() {
 var masterTimeout;
 $('#dropdownMaster').on('mouseover', function(e) {
@@ -79,12 +95,14 @@ function loginBtn() {
 	{
 	        // we must change the login button by a Disconnect button
 	        $('#loginNavbar').html('Logout');
-		$('#navbarDropdownMenuLink').show();
 		// The navBar title must be the login name
+		$("#dropdownMaster").append(dropdownCodeToInsert);
 		$('#navbarDropdownMenuLink').html(mylocalStorage['username']);
 	}
-	else
-		$('#navbarDropdownMenuLink').hide();
+	else {
+		console.log("Error with html text insertion");
+	}
+		
 }
 
 $("#Home").on("click", function(event) {


### PR DESCRIPTION
Created a security fix that prevents individuals from accessing the drop down without logging in first. Still needs to be tested

Procedure to test:

Open the CI page. Do not log in
Open up developer tools. Go to console and type in this command: $('#navbarDropdownMenuLink').removeAttr("style");, nothing should happen
Open up the source code, and search for navbarDropdownMenuLink. All code within the <li class="nav-item dropdown ml-md-auto" id="dropdownMaster"> should be commented out. I commented it out instead of deleted it for comparison purposes but in the final version, these comments should deleted from the source all together.
Procedure to make sure drop down actually shows up:

Log in. The dropdown should now appear.