### PR TITLE
Private Key Download Button Refinement

### DIFF
--- a/gateway/html/navbar.html
+++ b/gateway/html/navbar.html
@@ -66,7 +66,7 @@
 	data-toggle="modal" data-target="#modalSession" >End Session</button>
     
     <!-- Private Keys Button -->
-    <form method="get" action="./get_private_key">
+    <form method="get" action="./get_private_key" target="_blank">
       <button type="submit" class="btn btn-primary" id="download_key_button" data-toggle="modal" data-target="#myModal" style="display: none;">
         Download Private Key
       </button>

--- a/gateway/html/navbar.html
+++ b/gateway/html/navbar.html
@@ -16,7 +16,8 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="mylocalStorage['privKeyInfoAck'] = 1">Acknowledge</button>
+        <button type="button" class="btn btn-primary" data-dismiss="modal" id="ack_button">Acknowledge</button>
+
       </div>
     </div>
   </div>
@@ -66,11 +67,9 @@
 	data-toggle="modal" data-target="#modalSession" >End Session</button>
     
     <!-- Private Keys Button -->
-    <form method="get" action="./get_private_key" target="_blank">
-      <button type="submit" class="btn btn-primary" id="download_key_button" data-toggle="modal" data-target="#myModal" style="display: none;">
-        Download Private Key
-      </button>
-    </form>
+    <button type="submit" class="btn btn-primary" id="download_key_button" data-toggle="modal" data-target="#myModal" style="display: none;">
+      Download Private Key
+    </button>
     
     <!-- Dropdown -->
     <li class="nav-item dropdown ml-md-auto" id="dropdownMaster">

--- a/gateway/html/navbar.html
+++ b/gateway/html/navbar.html
@@ -66,7 +66,7 @@
 	data-toggle="modal" data-target="#modalSession" >End Session</button>
     
     <!-- Private Keys Button -->
-    <form method="get" action="/get_private_key">
+    <form method="get" action="./get_private_key">
       <button type="submit" class="btn btn-primary" id="download_key_button" data-toggle="modal" data-target="#myModal" style="display: none;">
         Download Private Key
       </button>

--- a/gateway/js/app.js
+++ b/gateway/js/app.js
@@ -923,6 +923,36 @@ function disconnect()
     	}, 5000);
 }
 
+function createCookie(name, value, days) {
+    var expires;
+
+    if (days) {
+        var date = new Date();
+        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+        expires = "; expires=" + date.toGMTString();
+    } else {
+        expires = "";
+    }
+    document.cookie = encodeURIComponent(name) + "=" + encodeURIComponent(value) + expires + "; path=/";
+}
+
+function readCookie(name) {
+    var nameEQ = encodeURIComponent(name) + "=";
+    var ca = document.cookie.split(';');
+    for (var i = 0; i < ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) === ' ')
+            c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) === 0)
+            return decodeURIComponent(c.substring(nameEQ.length, c.length));
+    }
+    return null;
+}
+
+function eraseCookie(name) {
+    createCookie(name, "", -1);
+}
+
 function mainpage(){
 	clearDocument();
 	// Must load the default home page

--- a/gateway/js/app.js
+++ b/gateway/js/app.js
@@ -961,9 +961,16 @@ function mainpage(){
 	loadJS("js/navbar.js");
 	navbarHover();
 	// pretty rudimentary I should probably keep this within the popUp function itself eventually
-	if (mylocalStorage['privKeyInfoAck'] != 1) {
+	AckCookieName = "priv_key_ack"
+	if (( "string" === typeof(mylocalStorage['secretKey']) ) & ( "string" === typeof(mylocalStorage['accessKey']) ))
+	{
+		AckCookieName = AckCookieName + "_username_" + mylocalStorage['username']
+	}
+	
+	if (readCookie(AckCookieName) != 1) {
 		popUp()
 	}
+	
 	loginBtn();
 	loadHTML("html/home.html");
 

--- a/gateway/js/navbar.js
+++ b/gateway/js/navbar.js
@@ -96,10 +96,10 @@ $("#download_key_button").click(function() {
 });
 
 $("#ack_button").click(function() {
-	let nameString = "downloaded"
+	let nameString = "priv_key_ack"
 	if (( "string" === typeof(mylocalStorage['secretKey']) ) & ( "string" === typeof(mylocalStorage['accessKey']) ))
 	{
-		nameString = nameString + " - username: " + mylocalStorage['username']
+		nameString = nameString + "_username_" + mylocalStorage['username']
 	}
     createCookie(nameString, 1, 30);
 });

--- a/gateway/js/navbar.js
+++ b/gateway/js/navbar.js
@@ -91,6 +91,20 @@ $("#Home").on("click", function(event) {
 	mainpage();
 });
 
+$("#download_key_button").click(function() {
+	window.location.href = "./get_private_key";
+});
+
+$("#ack_button").click(function() {
+	let nameString = "downloaded"
+	if (( "string" === typeof(mylocalStorage['secretKey']) ) & ( "string" === typeof(mylocalStorage['accessKey']) ))
+	{
+		nameString = nameString + " - username: " + mylocalStorage['username']
+	}
+    createCookie(nameString, 1, 30);
+});
+
+
 // tooltip element will appear/hide once the helptoggle is clicked
 function enableDisableToolTip() {
     let toolTip = document.getElementsByClassName('tooltiptext')

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -18,6 +18,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -342,12 +343,20 @@ func home(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(returnData))
 
 	case "get_private_key":
-		returnData, err := ioutil.ReadFile("/usr/local/production/keys/customer_private_key.pem")
+		priv_key_file := viper.GetString("CUSTOMER_PRIVATE_KEY")
+		returnData, err := ioutil.ReadFile(priv_key_file)
 		if err != nil {
 			base.Zlog.Fatalf("JSON encoding error: %s", err.Error())
 		}
+
+		//Scrape file name type
+		priv_key_file_type := filepath.Base(priv_key_file)
+
 		//if read is sucessful, get some information about the person doing stuff
 		base.Zlog.Infof("get_private_key: %s - %s %s %s", r.RemoteAddr, r.Proto, r.Method, r.URL.RequestURI())
+
+		//Set the response writer header to Content-Disposition to signify that the writer should initiate a download
+		w.Header().Set("Content-Disposition", "attachment; filename="+priv_key_file_type)
 
 		//Tell response writer to send the requester the file data in question
 		w.Write([]byte(returnData))

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -346,7 +346,7 @@ func home(w http.ResponseWriter, r *http.Request) {
 		priv_key_file := viper.GetString("CUSTOMER_PRIVATE_KEY")
 		returnData, err := ioutil.ReadFile(priv_key_file)
 		if err != nil {
-			base.Zlog.Fatalf("JSON encoding error: %s", err.Error())
+			base.Zlog.Fatalf("ReadFile error: %s", err.Error())
 		}
 
 		//Scrape file name type


### PR DESCRIPTION
In this commit, I refined the private key download button to possess the following qualities:

- Cookies
- Encapsulation within backend (server.go)
- Actually initiating a download instead of just opening up the file contents in the next page

**Purpose of Cookies**: allows user to disable post login popup by clicking the acknowledge button for 30 days. To test this, log into the dev ci and click the acknowledge button once the pop up loads. After this occurs, log out, and log back in. The popup should no longer appear for the next 30 days.

**Purpose of Encapsulation**: Improve readability of code. This code change was done purely for readability purposes so its effects can only be seen within the server.go file meaning there are no tests to be done. 

**Purpose of initiating download**: To ensure that when the user wants to download the button, the download is actually initiated by the browser, and the downloaded file can actually be located within the users local directory upon completion. To test this change, After logging in, click on the "Download Private Key" button. The private key button should show up on the bottom left of your browser after doing so. You can verify that the file contents are correct by opening it up from your local directory.




